### PR TITLE
Change hl-SpecialKey to stand out less.

### DIFF
--- a/colors/unicon.vim
+++ b/colors/unicon.vim
@@ -116,7 +116,7 @@ call s:HL('Todo', s:magenta, s:none, 'bold')
 ""}}}
 "" Extended highlighting "{{{
 "" ---------------------------------------------------------------------
-call s:HL('SpecialKey', s:base4, s:base2, 'bold')
+call s:HL('SpecialKey', s:base3)
 call s:HL('NonText', s:base3, s:none, 'bold')
 call s:HL('StatusLine', s:base6, s:base2, 'reverse')
 call s:HL('StatusLineNC', s:base4, s:base2, 'reverse')


### PR DESCRIPTION
Darken the fg and inherit the bg so that 'listchars' are better displayed.
Unprintable characters will be harder to see.

http://vimdoc.sourceforge.net/htmldoc/syntax.html#hl-SpecialKey

Before:
![image](https://user-images.githubusercontent.com/5081378/32511121-d085051e-c3c0-11e7-8bc7-d756d549038c.png)

After:
![image](https://user-images.githubusercontent.com/5081378/32511138-e0957ca4-c3c0-11e7-8cc1-4b2206d0deb2.png)
